### PR TITLE
Fix potential crashes in `FHermesContentEndpointModule::ShutdownModule()`

### DIFF
--- a/HermesCore/Source/HermesContentEndpoint/Private/HermesContentEndpoint.cpp
+++ b/HermesCore/Source/HermesContentEndpoint/Private/HermesContentEndpoint.cpp
@@ -63,13 +63,18 @@ void FHermesContentEndpointModule::ShutdownModule()
 	EditorExtension.UninstallAssetEditorExtension();
 	EditorExtension.UninstallContentBrowserExtension();
 
-	IHermesServerModule& Hermes = FModuleManager::GetModuleChecked<IHermesServerModule>("HermesServer");
-	Hermes.Unregister(NAME_EndpointId);
+	if (auto Hermes = FModuleManager::GetModulePtr<IHermesServerModule>("HermesServer"))
+	{
+		Hermes->Unregister(NAME_EndpointId);
+	}
 
 	if (AssetRegistryLoadedDelegateHandle.IsValid())
 	{
-		IAssetRegistry& AssetRegistry = FModuleManager::GetModuleChecked<FAssetRegistryModule>("AssetRegistry").Get();
-		AssetRegistry.OnFilesLoaded().Remove(AssetRegistryLoadedDelegateHandle);
+		if (IAssetRegistry* AssetRegistry = IAssetRegistry::Get())
+		{
+			AssetRegistry->OnFilesLoaded().Remove(AssetRegistryLoadedDelegateHandle);
+		}
+
 		AssetRegistryLoadedDelegateHandle.Reset();
 	}
 }


### PR DESCRIPTION
Hermes/AssetRegistry might already be unloaded at this point (while the editor is shutting down), there's not much point in expecting them to exist and crash if they don't.