### PR TITLE
Fix UE 5.5 deprecation warnings

### DIFF
--- a/HermesCore/Source/HermesContentEndpoint/Private/HermesContentEndpointEditorExtension.cpp
+++ b/HermesCore/Source/HermesContentEndpoint/Private/HermesContentEndpointEditorExtension.cpp
@@ -74,7 +74,11 @@ void FHermesContentEndpointEditorExtension::CopyEndpointURLsToClipboard(TArray<F
 	// Strip the final newline
 	const int32 LineTerminatorLen = FCString::Strlen(LINE_TERMINATOR);
 	checkf(ClipboardText.EndsWith(LINE_TERMINATOR), TEXT("There should always be at least one line terminator!"));
+#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 5 || ENGINE_MAJOR_VERSION > 5
+	ClipboardText.RemoveAt(ClipboardText.Len() - LineTerminatorLen, LineTerminatorLen, EAllowShrinking::No);
+#else
 	ClipboardText.RemoveAt(ClipboardText.Len() - LineTerminatorLen, LineTerminatorLen, false);
+#endif
 
 	FPlatformApplicationMisc::ClipboardCopy(*ClipboardText);
 }

--- a/HermesCore/Source/HermesServer/Public/Hermes.h
+++ b/HermesCore/Source/HermesServer/Public/Hermes.h
@@ -5,6 +5,7 @@
 #include "HermesUriSchemeProvider.h"
 
 #include <CoreMinimal.h>
+#include <Runtime/Launch/Resources/Version.h>
 
 namespace Hermes
 {
@@ -35,7 +36,11 @@ namespace Hermes
 		// The first character can only be an alphabetic character, so strip off any non-alphabetic ones
 		while (Input.Len() != 0 && !FChar::IsAlpha(Input[0]))
 		{
+#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 5 || ENGINE_MAJOR_VERSION > 5
+			Input.RemoveAt(0, 1, EAllowShrinking::No);
+#else
 			Input.RemoveAt(0, 1, false);
+#endif
 		}
 
 		if (Input.Len() > 0)


### PR DESCRIPTION
Fixed warning:
- 'FString::RemoveAt': RemoveAt with a boolean bAllowShrinking has been deprecated - please use the EAllowShrinking enum instead