### PR TITLE
Remove pragma-once from cpp file to fix clang error

### DIFF
--- a/HermesBranchSupport/Source/HermesBranchSupport/Private/HermesBranchSupport.cpp
+++ b/HermesBranchSupport/Source/HermesBranchSupport/Private/HermesBranchSupport.cpp
@@ -1,5 +1,4 @@
 // Copyright (c) Jørgen Tjernø <jorgen@tjer.no>. All rights reserved.
-#pragma once
 
 #include <CoreMinimal.h>
 #include <Features/IModularFeatures.h>


### PR DESCRIPTION
Fixes a compile error when building a UE 5.4 project with clang-cl v16.0.6.